### PR TITLE
BUILD-519: Handle hatId as Hex, not BigInt string

### DIFF
--- a/packages/hats-ponder-sdk/src/index.ts
+++ b/packages/hats-ponder-sdk/src/index.ts
@@ -1,5 +1,5 @@
 import { http } from 'viem';
-import type { Abi, Address } from 'viem';
+import type { Abi, Address, Hex } from 'viem';
 import { ponder } from 'ponder:registry';
 import { hat } from '../ponder.schema';
 import { HatsAbi } from '../abis/HatsAbi';
@@ -8,6 +8,7 @@ import { ERC6551RegistryAbi } from '../abis/ERC6551RegistryAbi';
 import { HatsModuleFactoryV0_6_0Abi } from '../abis/HatsModuleFactoryV0_6_0Abi';
 import { HatsModuleFactoryV0_7_0Abi } from '../abis/HatsModuleFactoryV0_7_0Abi';
 import { ModuleProxyFactoryAbi } from '../abis/ModuleProxyFactoryAbi';
+import { toHex } from 'viem';
 
 // Export schema
 export * from '../ponder.schema';
@@ -209,12 +210,15 @@ ponder.on('Hats:HatCreated', async ({ event, context }) => {
       ? 2147483647 // Use PostgreSQL integer max if the value is too large
       : Number(maxSupply);
 
+  // Convert id to hex the same way as the subgraph
+  const hatIdHex = '0x' + id.toString(16).padStart(64, '0');
+
   console.log('Indexing hat with chainId:', context.network.chainId);
 
   await context.db
     .insert(hat)
     .values({
-      id: id.toString(),
+      id: hatIdHex,
       chainId: Number(context.network.chainId),
       details,
       maxSupply: safeMaxSupply,
@@ -223,7 +227,7 @@ ponder.on('Hats:HatCreated', async ({ event, context }) => {
       mutable: mutable_,
       imageUri: imageURI,
       createdAt: event.block.timestamp.toString(),
-      lastHatId: id.toString(),
+      lastHatId: hatIdHex,
     })
     .onConflictDoNothing();
 });
@@ -232,10 +236,13 @@ ponder.on('Hats:HatCreated', async ({ event, context }) => {
 ponder.on('Hats:HatDetailsChanged', async ({ event, context }) => {
   const { hatId, newDetails } = event.args;
 
+  // Convert hatId to hex the same way as the subgraph
+  const hatIdHex = '0x' + hatId.toString(16).padStart(64, '0');
+
   await context.db
     .insert(hat)
     .values({
-      id: hatId.toString(),
+      id: hatIdHex,
       chainId: Number(context.network.chainId),
       details: newDetails,
     })
@@ -248,10 +255,13 @@ ponder.on('Hats:HatDetailsChanged', async ({ event, context }) => {
 ponder.on('Hats:HatEligibilityChanged', async ({ event, context }) => {
   const { hatId, newEligibility } = event.args;
 
+  // Convert hatId to hex the same way as the subgraph
+  const hatIdHex = '0x' + hatId.toString(16).padStart(64, '0');
+
   await context.db
     .insert(hat)
     .values({
-      id: hatId.toString(),
+      id: hatIdHex,
       chainId: Number(context.network.chainId),
       eligibility: newEligibility,
     })


### PR DESCRIPTION
# Overview

- Resolves BUILD-519
- Brings in the same conversion utility we have in the subgraph for the `hat.id`
- Started re-indexing after this and was fine, but got limited by hitting my RPC tier

```
{
  "data": {
    "hats": {
      "items": [
        {
          "id": "0x0000003800010007000000000000000000000000000000000000000000000000",
          "chainId": 11155111,
          "details": "ipfs://bafkreieezv74p4yb2dghgx5rmpntffarhbwkemec3eefuxp3c24zte22iu",
          "maxSupply": null,
          "eligibility": "0xBf02de1055526C59d6b58E59d36e76FD463f1af7",
          "toggle": null,
          "mutable": null,
          "imageUri": null,
          "createdAt": null,
          "lastHatId": null
        },
        {
          "id": "0x0000003800010008000000000000000000000000000000000000000000000000",
          "chainId": 11155111,
          "details": "ipfs://bafkreicbzreohbj2qzz7yfvht6law3bi6j3l5nbv7dhec4ezuf7s4pwsuu",
          "maxSupply": null,
          "eligibility": "0xbaeC7D38fE868CDD525D64359386874f53511481",
          "toggle": null,
          "mutable": null,
          "imageUri": null,
          "createdAt": null,
          "lastHatId": null
        }
      ]
    }
  }
}
```